### PR TITLE
Adding calculator by default

### DIFF
--- a/KDG.Boilerplate.Server/Controllers/CalculatorController.cs
+++ b/KDG.Boilerplate.Server/Controllers/CalculatorController.cs
@@ -1,0 +1,76 @@
+using KDG.Boilerplate.Models.DTO;
+using KDG.Boilerplate.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace KDG.Boilerplate.Server.Controllers;
+
+[ApiController]
+[Route("/api/[controller]")]
+public class CalculatorController : ControllerBase
+{
+    private readonly ICalculatorService _calculatorService;
+
+    public CalculatorController(ICalculatorService calculatorService)
+    {
+        _calculatorService = calculatorService;
+    }
+
+    [HttpPost("add")]
+    public async Task<IActionResult> Add([FromBody] CalculationRequest request)
+    {
+        var result = await _calculatorService.AddAsync(request.Number1, request.Number2);
+        return Ok(new { result = result });
+    }
+
+    [HttpPost("divide")]
+    public async Task<IActionResult> Divide([FromBody] CalculationRequest request)
+    {
+        var result = await _calculatorService.DivideAsync(request.Number1, request.Number2);
+        return Ok(new { result = result });
+    }
+
+
+    [HttpGet("history/{userId}")]
+    public async Task<IActionResult> GetHistory(string userId)
+    {
+        var history = await _calculatorService.GetCalculationHistoryAsync(userId);
+        return Ok(history);
+    }
+
+    [HttpPost("complex")]
+    public IActionResult ComplexCalculation([FromBody] ComplexCalculationRequest request)
+    {
+        var result = _calculatorService.PerformComplexCalculation(request);
+
+        if (result > 1000000)
+        {
+            return BadRequest("Result too large");
+        }
+
+        return Ok(new { result = result, timestamp = DateTime.Now });
+    }
+
+    [HttpDelete("clear-history")]
+    [Authorize]
+    public async Task<IActionResult> ClearHistory()
+    {
+        var userId = User.FindFirst("userId")?.Value;
+        await _calculatorService.ClearHistoryAsync(userId ?? "");
+        return Ok();
+    }
+
+    [HttpPost("batch")]
+    public async Task<IActionResult> BatchCalculations([FromBody] List<CalculationRequest> requests)
+    {
+        var results = new List<object>();
+
+        foreach (var request in requests)
+        {
+            var result = await _calculatorService.AddAsync(request.Number1, request.Number2);
+            results.Add(new { input = request, output = result });
+        }
+
+        return Ok(results);
+    }
+}

--- a/KDG.Boilerplate.Server/Models/DTO/Calculator.cs
+++ b/KDG.Boilerplate.Server/Models/DTO/Calculator.cs
@@ -1,0 +1,25 @@
+namespace KDG.Boilerplate.Models.DTO;
+
+public class CalculationRequest
+{
+    public double Number1 { get; set; }
+    public double Number2 { get; set; }
+}
+
+public class ComplexCalculationRequest
+{
+    public double[] Numbers { get; set; } = [];
+    public string Operation { get; set; } = string.Empty;
+    public int Iterations { get; set; }
+}
+
+public class CalculationHistory
+{
+    public string Id { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+    public string Operation { get; set; } = string.Empty;
+    public double Input1 { get; set; }
+    public double Input2 { get; set; }
+    public double Result { get; set; }
+    public DateTime Timestamp { get; set; }
+}

--- a/KDG.Boilerplate.Server/Program.cs
+++ b/KDG.Boilerplate.Server/Program.cs
@@ -25,14 +25,15 @@ builder.Services.AddSwaggerGen();
 var connectionString = builder.Configuration["ConnectionString"] ?? throw new Exception("Connection string not configured");
 
 // add DI services
-builder.Services.AddScoped<IDatabase<Npgsql.NpgsqlConnection, Npgsql.NpgsqlTransaction>>(provider => 
+builder.Services.AddScoped<IDatabase<Npgsql.NpgsqlConnection, Npgsql.NpgsqlTransaction>>(provider =>
   new KDG.Database.PostgreSQL(connectionString));
 builder.Services.AddScoped<IUserRepository, UserRepository>();
 builder.Services.AddScoped<IAuthService>(provider => new AuthService(
     builder.Configuration["Jwt:Key"] ?? throw new Exception("JWT Key not configured"),
-    builder.Configuration["Jwt:Issuer"] ?? throw new Exception("JWT Issuer not configured"), 
+    builder.Configuration["Jwt:Issuer"] ?? throw new Exception("JWT Issuer not configured"),
     builder.Configuration["Jwt:Audience"] ?? throw new Exception("JWT Audience not configured")
 ));
+builder.Services.AddScoped<ICalculatorService, CalculatorService>();
 
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>

--- a/KDG.Boilerplate.Server/Services/Calculator/CalculatorService.cs
+++ b/KDG.Boilerplate.Server/Services/Calculator/CalculatorService.cs
@@ -1,0 +1,113 @@
+using KDG.Boilerplate.Models.DTO;
+
+namespace KDG.Boilerplate.Services;
+
+public class CalculatorService : ICalculatorService
+{
+    // Issue 8: In-memory storage instead of proper database
+    private static readonly List<CalculationHistory> _history = new();
+
+    public async Task<double> AddAsync(double number1, double number2)
+    {
+        await Task.Delay(1); // Fake async work
+        var result = number1 + number2;
+
+        _history.Add(new CalculationHistory
+        {
+            Id = Guid.NewGuid().ToString(),
+            UserId = "unknown", // Should get from context
+            Operation = "add",
+            Input1 = number1,
+            Input2 = number2,
+            Result = result,
+            Timestamp = DateTime.Now
+        });
+
+        return result;
+    }
+
+    public async Task<double> DivideAsync(double number1, double number2)
+    {
+        await Task.Delay(1);
+
+        if (number2 == 0)
+        {
+            throw new DivideByZeroException("Cannot divide by zero");
+        }
+
+        var result = number1 / number2;
+
+        _history.Add(new CalculationHistory
+        {
+            Id = Guid.NewGuid().ToString(),
+            UserId = "unknown",
+            Operation = "divide",
+            Input1 = number1,
+            Input2 = number2,
+            Result = result,
+            Timestamp = DateTime.Now
+        });
+
+        return result;
+    }
+
+    public async Task<double> ModulusAsync(double number1, double number2)
+    {
+        await Task.Delay(1);
+
+        var result = number1 % number2;
+
+        _history.Add(new CalculationHistory
+        {
+            Id = Guid.NewGuid().ToString(),
+            UserId = "unknown",
+            Operation = "modulus",
+            Input1 = number1,
+            Input2 = number2,
+            Result = result,
+            Timestamp = DateTime.Now
+        });
+
+        return result;
+    }
+
+    public async Task<List<CalculationHistory>> GetCalculationHistoryAsync(string userId)
+    {
+        await Task.Delay(10); // Simulate database call
+        return _history.Where(h => h.UserId == userId).ToList();
+    }
+
+    public double PerformComplexCalculation(ComplexCalculationRequest request)
+    {
+        double result = 0;
+
+        for (int i = 0; i < request.Iterations; i++)
+        {
+            switch (request.Operation.ToLower())
+            {
+                case "sum":
+                    result += request.Numbers.Sum();
+                    break;
+                case "product":
+                    result = request.Numbers.Aggregate(1.0, (acc, x) => acc * x);
+                    break;
+                default:
+                    return 0;
+            }
+        }
+
+        return result;
+    }
+
+    public async Task ClearHistoryAsync(string userId)
+    {
+        await Task.Delay(5);
+        for (int i = _history.Count - 1; i >= 0; i--)
+        {
+            if (_history[i].UserId == userId)
+            {
+                _history.RemoveAt(i);
+            }
+        }
+    }
+}

--- a/KDG.Boilerplate.Server/Services/Calculator/CalculatorService.cs
+++ b/KDG.Boilerplate.Server/Services/Calculator/CalculatorService.cs
@@ -89,7 +89,7 @@ public class CalculatorService : ICalculatorService
                     result += request.Numbers.Sum();
                     break;
                 case "product":
-                    result = request.Numbers.Aggregate(1.0, (acc, x) => acc * x);
+                    result *= request.Numbers.Aggregate(1.0, (acc, x) => acc * x);
                     break;
                 default:
                     return 0;

--- a/KDG.Boilerplate.Server/Services/Calculator/ICalculatorService.cs
+++ b/KDG.Boilerplate.Server/Services/Calculator/ICalculatorService.cs
@@ -1,0 +1,12 @@
+using KDG.Boilerplate.Models.DTO;
+
+namespace KDG.Boilerplate.Services;
+
+public interface ICalculatorService
+{
+    Task<double> AddAsync(double number1, double number2);
+    Task<double> DivideAsync(double number1, double number2);
+    Task<List<CalculationHistory>> GetCalculationHistoryAsync(string userId);
+    double PerformComplexCalculation(ComplexCalculationRequest request);
+    Task ClearHistoryAsync(string userId);
+}


### PR DESCRIPTION
Testing BugBot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce calculator endpoints with in-memory history, complex and batch calculations, plus DI registration.
> 
> - **Backend/API**:
>   - Add `CalculatorController` with endpoints:
>     - `POST /api/Calculator/add`, `POST /divide`, `POST /complex`, `POST /batch`
>     - `GET /history/{userId}`
>     - `DELETE /clear-history` (requires authorization)
> - **Services**:
>   - Implement `CalculatorService` using in-memory `List<CalculationHistory>` for storage.
>   - Operations: `AddAsync`, `DivideAsync` (throws on divide-by-zero), `ModulusAsync`, `GetCalculationHistoryAsync`, `PerformComplexCalculation` (sum/product with iterations), `ClearHistoryAsync`.
> - **Models/DTOs**:
>   - Add `CalculationRequest`, `ComplexCalculationRequest`, and `CalculationHistory`.
> - **Dependency Injection**:
>   - Register `ICalculatorService` in `Program.cs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c966ecc79fa3db8d3e8eef2c93d7ed848a3b3d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->